### PR TITLE
Implemented channel operations and one-to-many example operation

### DIFF
--- a/backend/miscellaneous/channels.py
+++ b/backend/miscellaneous/channels.py
@@ -1,0 +1,54 @@
+"""
+Created on Fri Aug  9 15:26:45 2019
+
+@author: Bogdan
+"""
+import os, sys
+import cv2
+import numpy as np
+projectPath = os.getcwd()
+while os.path.basename(projectPath) != 'ImageTinkering':
+    projectPath = os.path.dirname(projectPath)
+sys.path.append(projectPath)
+from backend import utils
+
+
+def splitChannels(image, parameters):
+    """ Splits an image into its channels and returns them.
+    
+    Arguments:
+        *image* (NumPy array) -- the image to be split
+        
+        *parameters* (dictionary) -- a dictionary containing following keys:
+            
+            *spectrum* (str, optional) -- the spectrum in which the channels will
+            be represented; possible values are *grayscale* and *color*; default
+            value is *color*
+    
+    Returns:
+        list of NumPy array uint8 -- the channels of the image
+    """
+    if utils.isColor(image):
+        b = image[:,:,0]
+        g = image[:,:,1]
+        r = image[:,:,2]
+        
+        if 'spectrum' in parameters:
+            spectrum = parameters['spectrum']
+        else:
+            spectrum = 'color'
+        
+        if spectrum == 'color':
+            zeros = np.zeros((image.shape[:2]), dtype='uint8')
+            b = cv2.merge([b, zeros, zeros])
+            g = cv2.merge([zeros, g, zeros])
+            r = cv2.merge([zeros, zeros, r])
+        
+        return [b, g, r]
+    else:
+        return [image]
+
+def removeChannel(image, parameters):
+    """
+    """
+    pass

--- a/backend/miscellaneous/channels.py
+++ b/backend/miscellaneous/channels.py
@@ -3,6 +3,7 @@ Created on Fri Aug  9 15:26:45 2019
 
 @author: Bogdan
 """
+import copy
 import os, sys
 import cv2
 import numpy as np
@@ -13,7 +14,7 @@ sys.path.append(projectPath)
 from backend import utils
 
 
-def splitChannels(image, parameters):
+def split_channels(image, parameters):
     """ Splits an image into its channels and returns them.
     
     Arguments:
@@ -48,7 +49,42 @@ def splitChannels(image, parameters):
     else:
         return [image]
 
-def removeChannel(image, parameters):
+def remove_channels(image, parameters):
+    """ Zeroes out channels from an image.
+    
+    Arguments:
+        *image* (NumPy array) -- the image from which to remove channels
+        
+        *parameters* (dictionary) -- a dictionary containing following keys:
+            
+            *channel(s)* (str) -- the channel(s) to be removed from the image;
+            possible values are *red*, *green*, *blue*, *red & green*, *red & 
+            blue*, *green & blue*
+    Returns:
+        Numpy array uint8 -- the image having the requested channels removed
     """
-    """
-    pass
+    channelsInformation = parameters['channel(s)']
+    image_copy = copy.deepcopy(image)
+    
+    if '&' in channelsInformation:
+        # Zero out the two specified channels
+        channels = channelsInformation.split(' & ')
+        if channels[0] == 'red':
+            image_copy[:,:,2] = 0
+        elif channels[0] == 'green':
+            image_copy[:,:,1] = 0
+        
+        if channels[1] == 'green':
+            image_copy[:,:,1] = 0
+        elif channels[1] == 'blue':
+            image_copy[:,:,0] = 0
+    else:
+        # Zero out the specified channel
+        if channelsInformation == 'red':
+            image_copy[:,:,2] = 0
+        elif channelsInformation == 'green':
+            image_copy[:,:,1] = 0
+        else:
+            image_copy[:,:,0] = 0
+    
+    return image_copy

--- a/webui/static/config/operations.json
+++ b/webui/static/config/operations.json
@@ -131,6 +131,19 @@
       }
     ]
   },
+  "Split into Channels": {
+    "function": "miscellaneous.channels.split_channels",
+    "type": "one-to-many",
+    "parameters": [
+      {
+        "name": "spectrum",
+        "type": "lookup",
+        "values": ["grayscale", "color"],
+        "default": "color",
+        "description": "The spectrum in which the channels will be represented"
+      }
+    ]
+  },
   "Shuffle": {
     "function": "miscellaneous.shuffle.shuffle",
     "type": "one-to-one",

--- a/webui/static/config/operations.json
+++ b/webui/static/config/operations.json
@@ -144,6 +144,18 @@
       }
     ]
   },
+  "Remove Channels": {
+    "function": "miscellaneous.channels.remove_channels",
+    "type": "one-to-one",
+    "parameters": [
+      {
+        "name": "channel(s)",
+        "type": "lookup",
+        "values": ["red", "green", "blue", "red & green", "red & blue", "green & blue"],
+        "description": "The channel(s) to be removed from the image"
+      }
+    ]
+  },
   "Shuffle": {
     "function": "miscellaneous.shuffle.shuffle",
     "type": "one-to-one",


### PR DESCRIPTION
Implemented following channel operations:
    - Split into Channels: one-to-many operation which splits the image into the three composing channel images
    - Remove Channels: one-to-one operation which removes the channels specified by the user